### PR TITLE
HDM-561 Switch to Camel based storage proxy server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'solr_wrapper'
+  gem 'solr_wrapper', '0.18.0'
   gem 'fcrepo_wrapper'
   gem 'rspec-rails'
   gem 'capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -461,7 +461,8 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    solr_wrapper (0.12.1)
+    solr_wrapper (0.18.0)
+      faraday
       ruby-progressbar
       rubyzip
     solrizer (3.4.0)
@@ -552,7 +553,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  solr_wrapper
+  solr_wrapper (= 0.18.0)
   spring
   sqlite3
   turbolinks

--- a/lib/hydradam/storage_proxy_client.rb
+++ b/lib/hydradam/storage_proxy_client.rb
@@ -25,28 +25,34 @@ module HydraDAM
 
     def status(filename)
       # ping storage proxy for current status of @cache/@filename
+      Rails.logger.info 'Doing GET of ' + @host + ':' + @port.to_s + [@api_prefix,@cache_path, @cache, @cache_files_path, filename].join('/')
       connection.get [@api_prefix,@cache_path, @cache, @cache_files_path, filename].join('/')
+
     end
 
     def stage(filename)
-      # ping storage proxy for current status of @filename
-      connection.post [@api_prefix,'jobs', @cache, filename].join('/'), :type => 'stage'
-      # if status is not-staged
-      #   post a job to stage @filename
-      # end
+      Rails.logger.info 'Doing POST to ' + @host + ':' + @port.to_s + [@api_prefix,'jobs', @cache, filename, 'stage'].join('/')
+      connection.post do |req|
+        req.url [@api_prefix,'jobs', @cache, filename, 'stage'].join('/')
+        req.headers['Content-Type'] = 'application/json'
+      end
     end
 
     def unstage(filename)
-      # ping storage proxy for current status of @filename
-      connection.post [@api_prefix,'jobs', @cache, filename].join('/'), :type => 'unstage'
-      # if status is staged
-      #   post a job to unstage @filename
-      # end
+      Rails.logger.info 'Doing POST to ' + @host + ':' + @port.to_s + [@api_prefix,'jobs', @cache, filename, 'unstage'].join('/')
+      connection.post do |req|
+        req.url [@api_prefix,'jobs', @cache, filename, 'unstage'].join('/')
+        req.headers['Content-Type'] = 'application/json'
+      end
     end
 
     def fixity(filename, fixity_type = 'md5')
       # POST a job to initiate a fixity check on filename. fixity_type optional but defaults to md5
-      connection.post [@api_prefix,'jobs', @cache, filename].join('/'), :type => 'fixity', :fixity_type => fixity_type
+      Rails.logger.info 'Doing POST to ' + @host + ':' + @port.to_s + [@api_prefix,'jobs', @cache, filename, 'fixity'].join('/')
+      connection.post do |req|
+        req.url [@api_prefix,'jobs', @cache, filename, 'fixity'].join('/')
+        req.headers['Content-Type'] = 'application/json'
+      end
     end
 
     def available_actions

--- a/spec/lib/hydradam/storage_proxy_client_spec.rb
+++ b/spec/lib/hydradam/storage_proxy_client_spec.rb
@@ -18,21 +18,21 @@ describe 'HydraDAM::StorageProxyClient' do
         with(:headers => {'Accept'=>'*/*'}).
         to_return(:status => 404, :body => "", :headers => {})
 
-    WebMock.stub_request(:post, "http://localhost:3001/storage_api/jobs/SDADisk/unstaged_file.mp4").
-        with(:body => {"type"=>"stage"},
-             :headers => {'Accept'=>'*/*'}).
+    WebMock.stub_request(:post, "http://localhost:3001/storage_api/jobs/SDADisk/unstaged_file.mp4/stage").
+        with(
+             :headers => {'Accept'=>'*/*','Content-Type'=>'application/json'}).
         to_return(:status => 200, :body => '{"id":1,"name":"unstaged_file.mp4","type":"stage"}',
                   :headers => {"content-type":'application/json'})
 
-    WebMock.stub_request(:post, "http://localhost:3001/storage_api/jobs/SDADisk/staged_file.mp4").
-        with(:body => {"type"=>"unstage"},
+    WebMock.stub_request(:post, "http://localhost:3001/storage_api/jobs/SDADisk/staged_file.mp4/unstage").
+        with(
              :headers => {'Accept'=>'*/*'}).
         to_return(:status => 200, :body => '{"id":1,"name":"staged_file.mp4","type":"unstage"}',
                   :headers => {"content-type":'application/json'})
 
-    WebMock.stub_request(:post, "http://localhost:3001/storage_api/jobs/SDADisk/staged_file.mp4").
-        with(:body => {"type"=>"fixity", "fixity_type"=>"md5"},
-             :headers => {'Accept'=>'*/*'}).
+    WebMock.stub_request(:post, "http://localhost:3001/storage_api/jobs/SDADisk/staged_file.mp4/fixity").
+        with(
+             :headers => {'Accept'=>'*/*','Content-Type'=>'application/json'}).
         to_return(:status => 200, :body => '{"id":1,"name":"staged_file.mp4","type":"fixity"}',
                   :headers => {"content-type":'application/json'})
 


### PR DESCRIPTION
Making adjustments to switch from Rails based storage proxy mockup to the first version of the real Camel based proxy server.

Changes the job POST actions to be sent to RESTful endpoints instead of actions being parameterized in the body. 

The Camel proxy currently requires forcing a workable content type from the client side, but that might be remedied in future refactoring.

Also bumping up and forcing a newer solr_wrapper version to fix missing artifacts on download for CI. 